### PR TITLE
Fix bug in file cleanup handling and logging

### DIFF
--- a/MarketStructures8.py
+++ b/MarketStructures8.py
@@ -687,7 +687,7 @@ if __name__ == '__main__':
         latest_folder = os.path.join(src_folder, "latest")
         archive_folder = os.path.join(src_folder, "archive")
         #cleanup files. "Full cleanup true" moves old files from output to archive.
-        rename_move_and_archive_csv(src_folder, latest_folder, archive_folder, True)
+        rename_move_and_archive_csv(src_folder, latest_folder, archive_folder, "archive")
 
         logger.info("saving jita data")
         with_jita_price.to_csv('output/latest/jita_prices.csv', index=False)
@@ -718,7 +718,9 @@ if __name__ == '__main__':
     total_time_seconds = total_time.total_seconds()
     
     logger.info(
-        f"Time to complete:\nMARKET ORDERS: {round(mkt_time_seconds, 2)}s, avg: {round(Avg_market_response_time, 
-        2)}ms\nMARKET_HISTORY: {round(hist_time_seconds, 2)}s, avg: {round(hist_time_seconds/len(type_ids), 2)}ms")
+        "Time to complete:\n"
+        f"MARKET ORDERS: {round(mkt_time_seconds, 2)}s, avg: {round(Avg_market_response_time, 2)}ms\n"
+        f"MARKET_HISTORY: {round(hist_time_seconds, 2)}s, avg: {round(hist_time_seconds/len(type_ids), 2)}ms"
+    )
     logger.info(f"TOTAL TIME TO COMPLETE: {round(total_time_seconds, 2)}s")
     logger.info("="*80)

--- a/file_cleanup.py
+++ b/file_cleanup.py
@@ -90,8 +90,8 @@ def rename_move_and_archive_csv(src_folder, latest_folder, archive_folder, clean
 
     elif cleanup_mode == "latest_only":
         # Remove all but latest file
-        input("Are you sure you want to remove all but the latest file? (y/n)")
-        if input == "y":
+        response = input("Are you sure you want to remove all but the latest file? (y/n)")
+        if response == "y":
             for file in [f for f in os.listdir(archive_folder) if f.endswith(".csv")]:
                 os.remove(os.path.join(archive_folder, file))
                 logger.info(f"Removed from archive: {file}")


### PR DESCRIPTION
## Summary
- sanitize user confirmation in `file_cleanup`
- call `rename_move_and_archive_csv` with correct mode string
- fix multi-line logger message formatting

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683f40e7d6f0832fb268ccaa07d14294